### PR TITLE
Fix for cursor jumping to beginning of tinyMCE field.

### DIFF
--- a/lib/components/fields/textarea.js
+++ b/lib/components/fields/textarea.js
@@ -65,7 +65,9 @@ module.exports = function() {
 
     tinymce.init(options);
     this.$watch('value', function(val) {
+	if(val != tinymce.get("textarea_" + this.name).getContent()) {
       tinymce.get("textarea_" + this.name).setContent(val);
+ 	}
     });
 
   }


### PR DESCRIPTION
Hi Matanya,

Thanks for your vue-formular plugin. Great piece of code, very nice organised.

I have a pull request for the below.
Fix for cursor jumping to beginning of tinyMCE field when you focuses the textarea tinymce field or when you press enter.

See the demo page (https://jsfiddle.net/matfish2/fjurzoLj/) to reproduce the unwanted behaviour:
Error scenario #1. After initial page load, cick the WYSIWYG field and start typing 'abcd'. This will result in 'bcda'
Error scenario #2. In the WYSIWYG editor type a text and hit enter. The cursor will jump to te beginning of the editor field. This is unwanted behaviour.

The fix will only reset the content of the tinymce field when the synced value actually changes outside of the editor from your parent Vue component.
It's a string comparison (not optimal) but it fixes the above issues.

Thanks for your library, regards, Frank
